### PR TITLE
Pause menu

### DIFF
--- a/Assets/DefaultSongs/flow 3 - 3:1:24, 9.45 PM.mp3.meta
+++ b/Assets/DefaultSongs/flow 3 - 3:1:24, 9.45 PM.mp3.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: 9e357a7da9ddf4a42927ebba2ca4faaa
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/DefaultSongs/flow song 2 - 2:23:24, 5.13 PM.mp3.meta
+++ b/Assets/DefaultSongs/flow song 2 - 2:23:24, 5.13 PM.mp3.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: 5918f93f298bb4490899fcdbb314d249
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -452,7 +452,7 @@ RectTransform:
   - {fileID: 1999255252}
   - {fileID: 1398972981}
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -585,7 +585,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &734788018
 GameObject:
@@ -875,6 +875,104 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1371658651
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1524945621}
+    m_Modifications:
+    - target: {fileID: 1075564933531399200, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_text
+      value: Quit
+      objectReference: {fileID: 0}
+    - target: {fileID: 2129811076137720617, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: toLookAt.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.6590657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.822244
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.970295
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4597738700269411933, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_Name
+      value: Quit Button
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1703109803}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: QuitGame
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: MenuManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+--- !u!4 &1371658652 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+  m_PrefabInstance: {fileID: 1371658651}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1398972980
 GameObject:
   m_ObjectHideFlags: 0
@@ -960,6 +1058,106 @@ Transform:
 Transform:
   m_CorrespondingSourceObject: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
   m_PrefabInstance: {fileID: 120595324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1524945620
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1524945621}
+  m_Layer: 0
+  m_Name: Pause Buttons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1524945621
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1524945620}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.6590658, y: -7.822244, z: 18.970295}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1371658652}
+  - {fileID: 1606553910}
+  - {fileID: 1529791757}
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1529791756
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1524945621}
+    m_Modifications:
+    - target: {fileID: 1075564933531399200, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_text
+      value: Options
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.3409343
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.822244
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.970295
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4597738700269411933, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_Name
+      value: Options Button
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+--- !u!4 &1529791757 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+  m_PrefabInstance: {fileID: 1529791756}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1591955371
 PrefabInstance:
@@ -1050,6 +1248,100 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+--- !u!1001 &1606553909
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1524945621}
+    m_Modifications:
+    - target: {fileID: 1075564933531399200, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_text
+      value: Songs
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.6590658
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 11.822245
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.970295
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4597738700269411933, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: m_Name
+      value: Start Button
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1703109803}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SongSelect
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: MenuManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909252337509985590, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+      propertyPath: interactEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+--- !u!4 &1606553910 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2150184599727098566, guid: 7791f7a96d9783e44b25ebe473a8bb4f, type: 3}
+  m_PrefabInstance: {fileID: 1606553909}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1611963975
 GameObject:
   m_ObjectHideFlags: 0
@@ -1104,7 +1396,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1616251354
 GameObject:
@@ -1208,6 +1500,7 @@ MonoBehaviour:
   titleButtons: {fileID: 1232655364}
   songSelectButtons: {fileID: 1283760252}
   optionsButtons: {fileID: 921023071}
+  pauseButtons: {fileID: 1524945620}
 --- !u!4 &1703109804
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -79,6 +79,8 @@ public class GameManager : MonoBehaviour
     
     public async void StartSong()
     {
+        _score = 0;
+        hud.UpdateScore(0);
         _songTime = -graceTime;
         _beatIndex = 0;
         _playing = true;
@@ -104,8 +106,15 @@ public class GameManager : MonoBehaviour
     
     public void Resume()
     {
+        hud.UpdateScore(_score);
         _playing = true;
+        audioSource.time = _songTime + SongManager.Instance.GetSong().Offset;
         audioSource.Play();
+    }
+
+    public void Retry()
+    {
+        StartSong();
     }
 
     private void SpawnTarget(float x, float y, float distance)

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -96,6 +96,18 @@ public class GameManager : MonoBehaviour
         }
     }
 
+    public void Pause()
+    {
+        _playing = false;
+        audioSource.Pause();
+    }
+    
+    public void Resume()
+    {
+        _playing = true;
+        audioSource.Play();
+    }
+
     private void SpawnTarget(float x, float y, float distance)
     {
         var target = Instantiate(targetPrefab, this.transform);

--- a/Assets/Scripts/MenuManager.cs
+++ b/Assets/Scripts/MenuManager.cs
@@ -9,6 +9,7 @@ using UnityEngine.UI;
 enum MenuState
 {
     Play,
+    Paused,
     Title,
     SongSelect,
     Options
@@ -42,6 +43,7 @@ public class MenuManager : MonoBehaviour
     public GameObject titleButtons;
     public GameObject songSelectButtons;
     public GameObject optionsButtons;
+    public GameObject pauseButtons;
     private List<GameObject> _songButtons;
     private float _songButtonOffset;
     private MenuState _menuState;
@@ -63,6 +65,7 @@ public class MenuManager : MonoBehaviour
         titleButtons.SetActive(state == MenuState.Title);
         songSelectButtons.SetActive(state == MenuState.SongSelect);
         optionsButtons.SetActive(state == MenuState.Options);
+        pauseButtons.SetActive(state == MenuState.Paused);
     }
 
     private UnityEngine.Events.UnityAction CreateStartSongAction(int count)
@@ -148,9 +151,15 @@ public class MenuManager : MonoBehaviour
             {
                 ToggleMenuState(MenuState.Title);
             }
-            else
+            else if (_menuState == MenuState.Play)
             {
-                ToggleMenuState(MenuState.SongSelect);
+                GameManager.Instance.Pause();
+                ToggleMenuState(MenuState.Paused);
+            }
+            else if (_menuState == MenuState.Paused)
+            {
+                GameManager.Instance.Resume();
+                ToggleMenuState(MenuState.Play);
             }
         }
 

--- a/Assets/Scripts/MenuManager.cs
+++ b/Assets/Scripts/MenuManager.cs
@@ -53,7 +53,7 @@ public class MenuManager : MonoBehaviour
         _instance = this;
         _songButtons = new List<GameObject>();
     }
-    
+
     private void Start()
     {
         ToggleMenuState(MenuState.Title);
@@ -73,7 +73,6 @@ public class MenuManager : MonoBehaviour
         return () => { StartSong(count); };
     }
 
-
     public void SongSelect()
     {
         ToggleMenuState(MenuState.SongSelect);
@@ -90,6 +89,22 @@ public class MenuManager : MonoBehaviour
         _songButtonOffset = 0;
     }
 
+    public void Resume()
+    {
+        GameManager.Instance.Resume();
+        ToggleMenuState(MenuState.Play);
+    }
+    public void Retry()
+    {
+        GameManager.Instance.Retry();
+        ToggleMenuState(MenuState.Play);
+    }
+    
+    public void QuitSong()
+    {
+        ToggleMenuState(MenuState.SongSelect);
+    }
+    
     public void QuitGame()
     {
         Application.Quit();
@@ -124,6 +139,11 @@ public class MenuManager : MonoBehaviour
             button.TryGetComponent<SongTarget>(out var songTarget);
             songTarget.ToggleOutline(i == Mathf.RoundToInt(SongButtonOffset));
         }
+        
+        if (Input.GetKeyDown(KeyCode.Return))
+        {
+            StartSong(Mathf.RoundToInt(SongButtonOffset));
+        }
     }
 
     private void StartSong(int index)
@@ -132,42 +152,37 @@ public class MenuManager : MonoBehaviour
         SongManager.Instance.currentSongIndex = index;
         SongManager.Instance.currentDifficulty = "intermediate";
         GameManager.Instance.StartSong();
-        
-        // DontDestroyOnLoad(SongManager.Instance.gameObject);
-        // UnityEngine.SceneManagement.SceneManager.LoadScene("Main");
+    }
 
-        // Destroy(MenuManager.Instance.gameObject);
+    private void HandleEscape()
+    {
+        switch (_menuState)
+        {
+            case MenuState.Title:
+                QuitGame();
+                break;
+            case MenuState.SongSelect:
+                ToggleMenuState(MenuState.Title);
+                break;
+            case MenuState.Play:
+                ToggleMenuState(MenuState.Paused);
+                GameManager.Instance.Pause();
+                break;
+            case MenuState.Paused:
+                ToggleMenuState(MenuState.Play);
+                GameManager.Instance.Resume();
+                break;
+            case MenuState.Options:
+                ToggleMenuState(MenuState.Title);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
     }
 
     private void Update()
     {
-        if (Input.GetKeyDown(KeyCode.Escape))
-        {
-            if (_menuState == MenuState.Title)
-            {
-                QuitGame();
-            }
-            else if (_menuState == MenuState.SongSelect)
-            {
-                ToggleMenuState(MenuState.Title);
-            }
-            else if (_menuState == MenuState.Play)
-            {
-                GameManager.Instance.Pause();
-                ToggleMenuState(MenuState.Paused);
-            }
-            else if (_menuState == MenuState.Paused)
-            {
-                GameManager.Instance.Resume();
-                ToggleMenuState(MenuState.Play);
-            }
-        }
-
-        HandleSongButtons();
-
-        if (Input.GetKeyDown(KeyCode.Return))
-        {
-            StartSong(Mathf.RoundToInt(SongButtonOffset));
-        }
+        if (Input.GetKeyDown(KeyCode.Escape)) HandleEscape();
+        if (_menuState == MenuState.SongSelect) HandleSongButtons();
     }
 }


### PR DESCRIPTION
Added a pause menu with three options: continue, retry, and quit.
- Continue instantly resumes from where the song left off. If there are any targets left on the screen when the pause menu is activated, they disappear when the song is resumed. This is to disincentivize pausing as it can harm the competitive integrity of a rhythm game.
- Retry resets the score and restarts the current song that is playing.
- Quit returns the player to the song select page.